### PR TITLE
Adding support for multiple git providers

### DIFF
--- a/notifier.js
+++ b/notifier.js
@@ -24,10 +24,14 @@ function Notifier() {
 			}
 
 			// Accept the request and close the connection
-			response.writeHead( 202 );
+			if( notifier.process( data ) ) {
+				// Payload parsing successful
+				response.writeHead( 202 );
+			} else {
+				// Unrecognized payload
+				response.writeHead( 400 );
+			}
 			response.end();
-
-			notifier.process( data );
 		});
 	});
 
@@ -42,27 +46,91 @@ Notifier.prototype.listen = function() {
 	this.server.listen.apply( this.server, arguments );
 };
 
-Notifier.prototype.process = function( raw ) {
-	var refParts = raw.ref.split( "/" ),
-		type = refParts[ 1 ],
-		owner = raw.repository.owner.name,
-		repo = raw.repository.name,
-		data = {
-			commit: raw.after,
-			owner: owner,
-			repo: repo,
-			raw: raw
-		},
-		eventName = owner + "/" + repo + "/" + raw.ref.substr( 5 );
+Notifier.services = [
+	/* github */
+	function ( raw ) {
+		// console.log( raw );
+		// return true;
+		if ( "undefined" === typeof raw.ref )
+		{
+			return false;
+		}
 
-	if ( type === "heads" ) {
-		// Handle namespaced branches
-		data.branch = refParts.slice( 2 ).join( "/" );
-	} else if ( type === "tags" ) {
-		data.tag = refParts[ 2 ];
+		var refParts = raw.ref.split( "/" ),
+			type = refParts[ 1 ],
+			owner = raw.repository.owner.name,
+			repo = raw.repository.name,
+			data = {
+				commit: raw.after,
+				owner: owner,
+				repo: repo,
+				raw: raw
+			},
+			eventName = owner + "/" + repo + "/" + raw.ref.substr( 5 );
+
+		if ( type === "heads" ) {
+			// Handle namespaced branches
+			data.branch = refParts.slice( 2 ).join( "/" );
+		} else if ( type === "tags" ) {
+			data.tag = refParts[ 2 ];
+		}
+
+		this.emit( eventName, data );
+		return true;
+	},
+	/* bitbucket */
+	function ( raw ) {
+		if ( raw.canon_url !== 'https://bitbucket.org' || 'undefined' === raw.repository )
+		{
+			return false;
+		}
+
+		var repoParts = raw.repository.absolute_url.split('/'),
+			owner = repoParts[ 1 ],
+			repo = repoParts[ 2 ],
+			data = {
+				commit: null,
+				owner: owner,
+				repo: repo,
+				raw: raw
+			},
+			nodes = []
+			commit = null;
+
+		for( var i = 0; i < raw.commits.length; i++ ) {
+			commit = raw.commits[i];
+
+			if ( ( commit.branches instanceof Array && commit.brancheslength )
+				|| null != commit.branch) {
+
+				if( commit.branch != null)
+				{
+					data.branch = commit.branch
+				}
+
+				data.commit = commit.node;
+				eventName = owner + "/" + repo + "/" + commit.node.substr( 5 );
+				this.emit( eventName, data );
+
+			}
+		}
+
+		return true;
+	}
+]
+
+Notifier.prototype.process = function( raw ) {
+	var i = Notifier.services.length - 1;
+
+	for ( ; i >=0; i-- )
+	{
+		if ( Notifier.services[i].call( this, raw ) )
+		{
+			return true;
+		}
 	}
 
-	this.emit( eventName, data );
+	return false;
 };
 
 exports.Notifier = Notifier;

--- a/notifier.js
+++ b/notifier.js
@@ -24,7 +24,7 @@ function Notifier() {
 			}
 
 			// Accept the request and close the connection
-			if( notifier.process( data ) ) {
+			if ( notifier.process( data ) ) {
 				// Payload parsing successful
 				response.writeHead( 202 );
 			} else {
@@ -49,9 +49,7 @@ Notifier.prototype.listen = function() {
 Notifier.services = [
 	/* github */
 	function ( raw ) {
-		// console.log( raw );
-		// return true;
-		if ( "undefined" === typeof raw.ref )
+		if ( raw.ref )
 		{
 			return false;
 		}
@@ -80,12 +78,13 @@ Notifier.services = [
 	},
 	/* bitbucket */
 	function ( raw ) {
-		if ( raw.canon_url !== 'https://bitbucket.org' || 'undefined' === raw.repository )
-		{
+		if ( raw.canon_url !== 'https://bitbucket.org' || 'undefined' === raw.repository ) {
 			return false;
 		}
 
-		var repoParts = raw.repository.absolute_url.split('/'),
+		var commit,
+			i,
+		    repoParts = raw.repository.absolute_url.split( "/" ),
 			owner = repoParts[ 1 ],
 			repo = repoParts[ 2 ],
 			data = {
@@ -94,16 +93,15 @@ Notifier.services = [
 				repo: repo,
 				raw: raw
 			},
-			nodes = []
-			commit = null;
+			nodes = [];
 
-		for( var i = 0; i < raw.commits.length; i++ ) {
-			commit = raw.commits[i];
+		for( i = 0; i < raw.commits.length; i++ ) {
+			commit = raw.commits[ i ];
 
-			if ( ( commit.branches instanceof Array && commit.brancheslength )
+			if ( ( commit.branches && commit.branches.length )
 				|| null != commit.branch) {
 
-				if( commit.branch != null)
+				if ( commit.branch != null)
 				{
 					data.branch = commit.branch
 				}
@@ -111,7 +109,6 @@ Notifier.services = [
 				data.commit = commit.node;
 				eventName = owner + "/" + repo + "/" + commit.node.substr( 5 );
 				this.emit( eventName, data );
-
 			}
 		}
 
@@ -122,10 +119,8 @@ Notifier.services = [
 Notifier.prototype.process = function( raw ) {
 	var i = Notifier.services.length - 1;
 
-	for ( ; i >=0; i-- )
-	{
-		if ( Notifier.services[i].call( this, raw ) )
-		{
+	for ( ; i >= 0; i-- ) {
+		if ( Notifier.services[ i ].call( this, raw ) ) {
 			return true;
 		}
 	}

--- a/notifier.js
+++ b/notifier.js
@@ -82,9 +82,8 @@ Notifier.services = [
 			return false;
 		}
 
-		var commit,
-			i,
-		    repoParts = raw.repository.absolute_url.split( "/" ),
+		var commit, i,
+			repoParts = raw.repository.absolute_url.split( "/" ),
 			owner = repoParts[ 1 ],
 			repo = repoParts[ 2 ],
 			data = {

--- a/notifier.js
+++ b/notifier.js
@@ -78,7 +78,7 @@ Notifier.services = [
 	},
 	/* bitbucket */
 	function ( raw ) {
-		if ( raw.canon_url !== 'https://bitbucket.org' || 'undefined' === raw.repository ) {
+		if ( raw.repository && raw.canon_url === "https://bitbucket.org" ) {
 			return false;
 		}
 
@@ -111,7 +111,6 @@ Notifier.services = [
 				this.emit( eventName, data );
 			}
 		}
-
 		return true;
 	}
 ]


### PR DESCRIPTION
I'm sure this could be improved, but for now it works with github as it always has, and works in a limited capacity with bitbucket.  But enough to at least know which branch was effected if not the tag.
